### PR TITLE
对 php7.4 的支持，以及debug页面使用国内cdn镜像

### DIFF
--- a/resources/views/vendor/log-viewer/bootstrap-3/_master.blade.php
+++ b/resources/views/vendor/log-viewer/bootstrap-3/_master.blade.php
@@ -7,9 +7,9 @@
     <title>LogViewer - Created by ARCANEDEV</title>
     <meta name="description" content="LogViewer">
     <meta name="author" content="ARCANEDEV">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link href='https://fonts.googleapis.com/css?family=Montserrat:400,700|Source+Sans+Pro:400,600' rel='stylesheet'
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.5/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.4.0/css/font-awesome.min.css">
+    <link href='https://fonts.loli.net/css?family=Montserrat:400,700|Source+Sans+Pro:400,600' rel='stylesheet'
           type='text/css'>
     <style>
         html {
@@ -331,9 +331,9 @@
 </footer>
 
 {{-- Scripts --}}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.3.0/Chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/jquery/jquery@1.11.3/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.5/dist/css/bootstrap.min.css"></script>
+<script src="https://cdnjs.loli.net/ajax/libs/Chart.js/2.3.0/Chart.min.js"></script>
 <script>
     Chart.defaults.global.responsive = true;
     Chart.defaults.global.scaleFontFamily = "'Source Sans Pro'";

--- a/resources/views/vendor/log-viewer/bootstrap-4/_master.blade.php
+++ b/resources/views/vendor/log-viewer/bootstrap-4/_master.blade.php
@@ -7,10 +7,9 @@
     <meta name="author" content="ARCANEDEV">
     <title>LogViewer - Created by ARCANEDEV</title>
     {{-- Styles --}}
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-          integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link href='https://fonts.googleapis.com/css?family=Montserrat:400,700|Source+Sans+Pro:400,600' rel='stylesheet'
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.4.0/css/font-awesome.min.css">
+    <link href='https://fonts.loli.net/css?family=Montserrat:400,700|Source+Sans+Pro:400,600' rel='stylesheet'
           type='text/css'>
     <style>
         html {
@@ -259,11 +258,10 @@
 </footer>
 
 {{-- Scripts --}}
-<script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
-        crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/jquery/jquery@3.2.1/dist/jquery.min.js"></script>
+<script src="https://cdnjs.loli.net/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"></script>
+<script src="https://cdnjs.loli.net/ajax/libs/Chart.js/2.7.1/Chart.min.js"></script>
 
 @yield('modals')
 @yield('scripts')

--- a/resources/views/vendor/log-viewer/bootstrap-4/show.blade.php
+++ b/resources/views/vendor/log-viewer/bootstrap-4/show.blade.php
@@ -251,7 +251,7 @@
             $('.stack-content').each(function () {
                 var $this = $(this);
                 var html = $this.html().trim()
-                    .replace(/({!! join(log_styler()->toHighlight(), '|') !!})/gm, '<strong>$1</strong>');
+                    .replace(/({!! join('|', log_styler()->toHighlight()) !!})/gm, '<strong>$1</strong>');
 
                 $this.html(html);
             });


### PR DESCRIPTION
在 php7.4 中，join的参数里将字符放在前面。

相关报错(500页面错误)

> [2020-07-23 20:08:19] local.ERROR: join(): Passing glue string after array is deprecated. Swap the parameters (View: /var/www/oneManager/resources/views/vendor/log-viewer/bootstrap-4/show.blade.php) {"userId":2,"exception":"[object] (ErrorException(code: 0): join(): Passing glue string after array is deprecated. Swap the parameters (View: /var/www/oneManager/resources/views/vendor/log-viewer/bootstrap-4/show.blade.php) at /var/www/oneManager/storage/framework/views/ca.php:260, ErrorException(code: 0): join(): Passing glue string after array is deprecated. Swap the parameters at /var/www/oneManager/storage/framework/views/ca.php:260)
[stacktrace]

----
修改了 /admin/debug 页面使用的代理